### PR TITLE
Catching *-syntax(define-syntax, let-syntax, etc.) based local identifier binding

### DIFF
--- a/.github/workflows/install-akku.sh
+++ b/.github/workflows/install-akku.sh
@@ -6,5 +6,5 @@ tar -zxvf akku-1.1.0.tar.gz
 cd akku-1.1.0
 ./configure
 make -j $(getconf _NPROCESSORS_ONLN)
-make install
+sudo make install
 cd ..

--- a/.github/workflows/install-chez-exe.sh
+++ b/.github/workflows/install-chez-exe.sh
@@ -4,5 +4,5 @@ git clone https://github.com/gwatt/chez-exe.git
 cd chez-exe
 scheme --script gen-config.ss --bootpath "../ChezScheme/$TARGET_MACHINE/boot/$TARGET_MACHINE"
 make -j $(getconf _NPROCESSORS_ONLN)
-make install
+sudo make install
 cd ..

--- a/.github/workflows/install-chez.sh
+++ b/.github/workflows/install-chez.sh
@@ -12,5 +12,5 @@ case "$TARGET_MACHINE" in
     curl -Ls https://github.com/burgerrg/win-iconv/releases/download/v0.0.9/iconv-x86.dll > "$TARGET_MACHINE"/bin/"$TARGET_MACHINE"/iconv.dll
     ;;
 esac
-make install
+sudo make install
 cd ..

--- a/README.md
+++ b/README.md
@@ -94,18 +94,19 @@ This project is still in early development, so you may run into rough edges with
 ![Find references with telescope.nvim](./doc/figure/find-references.png "Find references with telescope.nvim")
 7. Document symbol.
 ![Find document symbols with telescope.nvim](./doc/figure/document-symbol.png "find document symbols with telescope.nvim")
+8. Catching *-syntax(define-syntax, let-syntax, etc.) based local identifier binding. But Chez Scheme's `get-datum/annotations` won't parse quoted s-expression, and `syntax-case` rule is barried. This problem will be completely solved with self-made annotator.
+
 ### TODOs
 
-8. Renaming.
-9. *-syntax(define-syntax, let-syntax, etc.) based local identifier binding.
-10. Fully compatible with r6rs standard.
-11. Cross-platform Parallel indexing.
-12. Macro expanding.
-13. Code eval.
-14. Code diagnostic.
-15. Add cross-language semantic supporting.
-16. Self-made annotator.
-17. Type inference.
+9. Renaming. 
+11. Fully compatible with r6rs standard.
+12. Cross-platform parallel indexing.
+13. Macro expanding.
+14. Code eval.
+15. Code diagnostic.
+16. Add cross-language semantic supporting. Well, would java, c, python and many other languages can be supported with an AST transformer?
+17. Self-made annotator.
+18. Type inference.
 
 ## TODO:Contributing 
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ compile-chez-program run.ss
 #### TODO: for Windows
 The `run` file is also executable for windows WSL environment, and I'm waiting for [Chez Scheme 10](https://github.com/cisco/ChezScheme/wiki/Announcements). As their announcement, they will merge the racket implemented [Chez Scheme](https://cisco.github.io/ChezScheme/) into main branch. And in [this page](https://github.com/racket/ChezScheme/blob/master/BUILDING) it seems that the racket implementation has solved the multi-thread problem.
 
-### Manual Installation for [LunarVim](https://www.lunarvim.org/)
-In the near future, I will pull request to [mason.nvim](https://github.com/williamboman/mason.nvim) and [mason-lspconfig.nvim](https://github.com/williamboman/mason-lspconfig.nvim). In that case, you will be able to get this implementation automatically with [LunarVim](https://www.lunarvim.org/).
+### Installation for [LunarVim](https://www.lunarvim.org/)
+I have pull request to [mason.nvim](https://github.com/williamboman/mason.nvim) and [mason-lspconfig.nvim](https://github.com/williamboman/mason-lspconfig.nvim). In that case, you can get this implementation automatically with [LunarVim](https://www.lunarvim.org/). 
 
-But now, for installed plugin [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/), we have to manually do some installation: after manually building from above step [Building](#building), an executable file `run`  would be available at `{path-to-run}`. Then, create file `~/.local/share/lunarvim/site/pack/packer/start/nvim-lspconfig/lua/lspconfig/server_configurations/scheme_langserver.lua` as follows:
+But now, above configuration haven't been tested. So, manual installation is still needed: for installed plugin [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/), after manually building from above step [Building](#building), an executable file `run`  would be available at `{path-to-run}`. Then, create file `~/.local/share/lunarvim/site/pack/packer/start/nvim-lspconfig/lua/lspconfig/server_configurations/scheme_langserver.lua` as follows:
 ```lua
 local util = require 'lspconfig.util'
 local bin_name = '{path-to-run}'

--- a/analysis/dependency/file-linkage.sls
+++ b/analysis/dependency/file-linkage.sls
@@ -27,6 +27,7 @@
     (scheme-langserver analysis dependency rules involve)
 
     (scheme-langserver util dedupe)
+    (scheme-langserver util contain)
 
     (scheme-langserver virtual-file-system index-node)
     (scheme-langserver virtual-file-system document)
@@ -339,6 +340,4 @@
           (append path `(,n))
           '())
         )]))
-(define (contain? list-instance item)
-  (if (filter (lambda(i) (equal? i item)) list-instance) #t #f))
 )

--- a/analysis/dependency/file-linkage.sls
+++ b/analysis/dependency/file-linkage.sls
@@ -24,7 +24,7 @@
     (scheme-langserver analysis util)
 
     (scheme-langserver analysis dependency rules library-import)
-    (scheme-langserver analysis dependency rules involve)
+    (scheme-langserver analysis dependency rules load)
 
     (scheme-langserver util dedupe)
     (scheme-langserver util contain)
@@ -288,9 +288,9 @@
               (dedupe (apply append 
                 (map (lambda (index-node) (get-imported-libraries-from-index-node root-library-node index-node))
                   (document-index-node-list (file-node-document file-node)))))]
-            [involved-files 
+            [loaded-files 
               (dedupe (apply append 
-                (map (lambda (index-node) (involve-process root-library-node (file-node-document file-node) index-node))
+                (map (lambda (index-node) (load-process root-library-node (file-node-document file-node) index-node))
                   (document-index-node-list (file-node-document file-node)))))])
 
         (map (lambda (imported-library-path) 
@@ -304,7 +304,7 @@
                 (matrix-set! matrix 
                   (hashtable-ref path->id-map path #f) 
                   (hashtable-ref path->id-map (file-node-path file-node) #f)))
-          involved-files)
+          loaded-files)
         
         (loop (cdr file-nodes)))))
   (map  (lambda (node) 

--- a/analysis/identifier/rules/syntax.sls
+++ b/analysis/identifier/rules/syntax.sls
@@ -21,13 +21,19 @@
       [expression (annotation-stripped ann)])
     (try
       (match expression
+        [('identifier-syntax ((? symbol? id0) template1) ((set! (? symbol? id1) expression0) template2 ...))
+          (guard-for document index-node 'identifier-syntax '(chezscheme) '(rnrs) '(rnrs base) '(scheme))
+          (let* ([children (index-node-children index-node)]
+              [second-index-node (caddr children)]
+              [expression0-index-node (caddr (index-node-children second-index-node))])
+            (clause-process document second-index-node expression0-index-node second-index-node '()))]
         [('with-syntax ((pattern expression) **1) body ...)
           (guard-for document index-node 'with-syntax '(chezscheme) '(rnrs) '(rnrs base) '(scheme))
           (let* ([pattern-expression (cdr (index-node-children index-node))])
             (let loop ([children (index-node-children pattern-expression)])
               (if (not (null? children))
                 (body 
-                  (clause-process document (car children) index-node '())
+                  (clause-process document (car children) (car (index-node-children (car children))) index-node '())
                   (loop (cdr children))))))]
         [('syntax-rules (literals ...) (a b ...) **1) 
           (guard-for document index-node 'syntax-rules '(chezscheme) '(rnrs) '(rnrs base) '(scheme))
@@ -36,22 +42,22 @@
           (let ([rest (cddr (index-node-children index-node))])
             ;(a b)
             (map (lambda (clause-index-node)
-              (clause-process document clause-index-node clause-index-node literals))
+              (clause-process document clause-index-node clause-index-node (car (index-node-children clause-index-node)) literals))
               rest))]
         [('syntax-case to-match (literals ...) (a b ...) **1) 
           (guard-for document index-node 'syntax-case '(chezscheme) '(rnrs) '(rnrs base) '(scheme))
           (let ([rest (cdddr (index-node-children index-node))])
             ;(a b)
             (map (lambda (clause-index-node)
-              (clause-process document clause-index-node clause-index-node literals))
+              (clause-process document clause-index-node (car (index-node-children clause-index-node)) clause-index-node literals))
               rest))]
         [else '()])
       (except c
         [else '()]))))
 
-(define (clause-process document index-node target-index-node literals)
-  (let* ([template-index-node (car (index-node-children index-node))]
-      [ann (index-node-datum/annotations template-index-node)]
+(define (clause-process document index-node template-index-node target-index-node literals)
+  (let* ([ann (index-node-datum/annotations template-index-node)]
+    ; [template-index-node (car (index-node-children index-node))]
       [expression (annotation-stripped ann)]
       [symbols 
         (filter 

--- a/analysis/identifier/rules/syntax.sls
+++ b/analysis/identifier/rules/syntax.sls
@@ -1,0 +1,81 @@
+(library (scheme-langserver analysis identifier rules syntax)
+  (export syntax-process)
+  (import 
+    (chezscheme) 
+    (ufo-match)
+
+    (scheme-langserver util try)
+    (scheme-langserver util contain)
+
+    (scheme-langserver analysis identifier reference)
+
+    (scheme-langserver virtual-file-system index-node)
+    (scheme-langserver virtual-file-system document)
+    (scheme-langserver virtual-file-system file-node))
+
+; reference-identifier-type include 
+; syntax-parameter 
+;https://www.zenlife.tk/scheme-hygiene-macro.md
+(define (syntax-process root-file-node document index-node)
+  (let* ([ann (index-node-datum/annotations index-node)]
+      [expression (annotation-stripped ann)])
+    (try
+      (match expression
+        [('syntax-rules (literals ...) (a b) **1) 
+          (guard-for document index-node 'syntax-rules '(chezscheme) '(rnrs) '(rnrs base) '(scheme))
+        ; https://www.scheme.com/tspl4/syntax.html
+        ; Any syntax-rules form can be expressed with syntax-case by making the lambda expression and syntax expressions explicit.
+          (let ([rest (cdddr (index-node-children index-node))])
+            (map (lambda (clause-index-node)
+              (clause-process clause-index-node literals))
+              rest))]
+        [('syntax-case to-match (literals ...) (a b) **1) 
+          (guard-for document index-node 'syntax-case '(chezscheme) '(rnrs) '(rnrs base) '(scheme))
+          (let ([rest (cdddr (index-node-children index-node))])
+            (map (lambda (clause-index-node)
+              (clause-process clause-index-node literals))
+              rest))]
+        [else '()])
+      (except c
+        [else '()]))))
+
+(define (clause-process index-node literals)
+  (let* ([template-index-node (car (index-node-children index-node))]
+      [ann (index-node-datum/annotations templage-index-node)]
+      [expression (annotation-stripped ann)]
+      [symbols 
+        (filter 
+          (lambda (symbol)
+            (not (contain? literals symbol)))
+          (get-all-symbols expression))])
+    (map 
+      (lambda (symbol)
+        (let ([reference 
+              (make-identifier-reference
+                expression
+                document
+                index-node
+                '()
+                'syntax-parameter)])
+          (index-node-references-export-to-other-node-set! 
+            template-index-node
+            (append 
+              (index-node-references-export-to-other-node template-index-node)
+              `(,reference)))
+
+          (index-node-references-import-in-this-node-set! 
+            index-node
+            (append 
+              (index-node-references-import-in-this-node index-node)
+              `(,reference)))
+          `(,reference)))
+      symbols)))
+
+(define (get-all-symbols s-expression)
+  (if (symbol? s-expression)
+    `(,s-expression)
+    (cond
+      [(list? s-expression) (apply append (map get-all-symbols s-expression))]
+      [(vector? s-expression) (apply append (vector->list (vector-map get-all-symbols s-expression)))]
+      [else '()])))
+)

--- a/analysis/identifier/rules/syntax.sls
+++ b/analysis/identifier/rules/syntax.sls
@@ -27,7 +27,7 @@
             (let loop ([children (index-node-children pattern-expression)])
               (if (not (null? children))
                 (body 
-                  (clause-process (car children) index-node '())
+                  (clause-process document (car children) index-node '())
                   (loop (cdr children))))))]
         [('syntax-rules (literals ...) (a b ...) **1) 
           (guard-for document index-node 'syntax-rules '(chezscheme) '(rnrs) '(rnrs base) '(scheme))
@@ -36,22 +36,22 @@
           (let ([rest (cddr (index-node-children index-node))])
             ;(a b)
             (map (lambda (clause-index-node)
-              (clause-process clause-index-node clause-index-node literals))
+              (clause-process document clause-index-node clause-index-node literals))
               rest))]
         [('syntax-case to-match (literals ...) (a b ...) **1) 
           (guard-for document index-node 'syntax-case '(chezscheme) '(rnrs) '(rnrs base) '(scheme))
           (let ([rest (cdddr (index-node-children index-node))])
             ;(a b)
             (map (lambda (clause-index-node)
-              (clause-process clause-index-node clause-index-node literals))
+              (clause-process document clause-index-node clause-index-node literals))
               rest))]
         [else '()])
       (except c
         [else '()]))))
 
-(define (clause-process index-node target-index-node literals)
+(define (clause-process document index-node target-index-node literals)
   (let* ([template-index-node (car (index-node-children index-node))]
-      [ann (index-node-datum/annotations templage-index-node)]
+      [ann (index-node-datum/annotations template-index-node)]
       [expression (annotation-stripped ann)]
       [symbols 
         (filter 

--- a/analysis/workspace.sls
+++ b/analysis/workspace.sls
@@ -42,6 +42,7 @@
     (scheme-langserver analysis identifier rules library-export)
     (scheme-langserver analysis identifier rules library-import)
     (scheme-langserver analysis identifier rules lambda)
+    (scheme-langserver analysis identifier rules syntax)
     (scheme-langserver analysis identifier rules let)
     (scheme-langserver analysis identifier rules load)
 
@@ -181,6 +182,7 @@
   ;;2
   (let-process root-file-node document index-node)
   (lambda-process root-file-node document index-node)
+  (syntax-process root-file-node document index-node)
   (load-process root-file-node document index-node)
 
   (map 

--- a/util/contain.sls
+++ b/util/contain.sls
@@ -1,0 +1,10 @@
+(library (scheme-langserver util contain)
+    (export contain?)
+    (import (rnrs))
+
+(define contain? 
+    (case-lambda
+        [(list-instance item) (contain? list-instance item equal?)]
+        [(list-instance item equal-predicator) 
+            (if (filter (lambda(i) (equal-predicator i item)) list-instance) #t #f)]))
+)


### PR DESCRIPTION
But Chez Scheme's `get-datum/annotations` won't parse quoted s-expression, and `syntax-case` rule is barried. This problem will be completely solved with self-made annotator.