### PR TITLE
Add Dockerfile and GH actions testing workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,14 @@
+name: Test
+
+on:
+  pull_request:
+    branches: main
+
+jobs:
+   build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build and test
+      run: docker run $(docker build -q .)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:latest as build-chez
+
+RUN apk update && apk --no-cache --update add \
+    gcc git make musl-dev curl \
+    ncurses ncurses-dev util-linux-dev
+
+WORKDIR /root/
+RUN curl -L https://github.com/cisco/ChezScheme/releases/download/v9.6.4/csv9.6.4.tar.gz | tar -zx
+RUN mv csv9.6.4 ChezScheme
+
+WORKDIR /root/ChezScheme
+RUN ./configure --threads --disable-x11
+RUN make && make install
+
+
+
+FROM akkuscm/akku
+RUN apk update && apk --no-cache --update add bash
+
+# Ensure that there are no collisions
+RUN rm -rf /usr/lib/csv9.6.4/
+
+COPY --from=build-chez /usr/bin/scheme /usr/bin/
+COPY --from=build-chez /usr/lib/csv9.6.4/ /usr/lib/csv9.6.4/
+
+RUN mkdir /root/scheme-langserver/
+WORKDIR /root/scheme-langserver/
+
+COPY Akku.lock Akku.manifest /root/scheme-langserver/
+
+# Install deps (most important operation to cache)
+RUN akku install
+
+COPY util /root/scheme-langserver/util/
+COPY protocol /root/scheme-langserver/protocol/
+COPY virtual-file-system /root/scheme-langserver/virtual-file-system/
+COPY analysis /root/scheme-langserver/analysis/
+COPY tests /root/scheme-langserver/tests/
+
+COPY scheme-langserver.sls output-type-analysis.ss test.sh run.ss /root/scheme-langserver/
+
+# Install project
+RUN akku install
+
+
+ENTRYPOINT [ "./test.sh" ]

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # akku install
 # bash .akku/env
 compile-chez-program run.ss

--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,19 @@
-find  ./tests ! -path "./tests/output-identifier-types.sps" ! -path "./tests/parallel-log-debug.sps" ! -path "./tests/log-debug.sps" -name "*sps" -exec scheme --script {} \; 
+#!/usr/bin/env bash
+source .akku/bin/activate
+
+skip=(
+    "./tests/output-identifier-types.sps" 
+    "./tests/parallel-log-debug.sps" 
+    "./tests/log-debug.sps" 
+)
+
+success=0
+
+for test in $(find ./tests | grep ".sps$")
+do
+    if [[ "${skip[@]}" =~ $test ]]; then continue; fi
+    scheme --quiet $test
+    success=$(($? || $success))
+done;
+
+exit $success


### PR DESCRIPTION
cc: @ufo5260987423 

This PR implements a GH actions testing workflow and adds a `Dockerfile`. It aims to resolve #35.

* To achieve this, I also had to change `test.sh`. This PR doesn't modify its behavior, just the exit codes, as I wanted `test.sh` to return 0 if and only if all tests passed.
* The Dockerfile can be modified to build whatever version of Chez Scheme we want, as we override the version of Chez in the Akku Alpine image.

Notes & topics to discuss:
* I still would like to add Nix support, if that's still on the table. I can do it in a different PR, or I can do it in this one and then rewrite the Dockerfile to use the Nix environment. I'm happy with either.