### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,6 @@ jobs:
             bash -c 'source .akku/bin/activate
                      compile-chez-program run.ss
                      mv run build/run || exit 1
-                     echo Build Success
                      '
 
       - name: Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,5 +32,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           repo: konst-aa/scheme-langserver
-          files: run
+          files: build/run
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,15 +12,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Prepare release assets
+      - name: Build image
+        run: docker build .
+
+      - name: Compile
         run: |
-          cd .. \
-          && tar czf "Source code.zip" scheme-langserver \
-          && cd scheme-langserver
+          mkdir build \
+          && docker run \
+            -v ./build:/root/scheme-langserver/build/ \
+            $(docker build -q .) \
+            bash -c 'source .akku/bin/activate
+                     compile-chez-program run.ss
+                     mv run buil/run || exit 1
+                     echo Build Success
+                     '
 
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           repo: konst-aa/scheme-langserver
-          files: |
-            "Source code.zip"
+          files: run
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,5 @@
-name: Release # stub from https://github.com/softprops/action-gh-release
+# stub from https://github.com/softprops/action-gh-release
+name: Release 
 on:
   push:
     tags:
@@ -23,7 +24,7 @@ jobs:
             $(docker build -q .) \
             bash -c 'source .akku/bin/activate
                      compile-chez-program run.ss
-                     mv run buil/run || exit 1
+                     mv run build/run || exit 1
                      echo Build Success
                      '
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+name: Release # stub from https://github.com/softprops/action-gh-release
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare release assets
+        run: |
+          cd .. \
+          && tar czf "Source code.zip" scheme-langserver \
+          && cd scheme-langserver
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          repo: konst-aa/scheme-langserver
+          files: |
+            "Source code.zip"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on:
     branches: main
 
 jobs:
-   build-and-deploy:
+   build-and-test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build and test
-      run: docker run $(docker build -q .)
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build image
+      run: docker build .
+
+    - name: Test
+      run: docker run $(docker build -q .) ./test.sh
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:latest as build-chez
+# Install chez
+FROM debian:bullseye AS build-chez
 
-RUN apk update && apk --no-cache --update add \
-    gcc git make musl-dev curl \
-    ncurses ncurses-dev util-linux-dev
+RUN apt-get update && apt-get install -y \
+        curl build-essential git uuid-dev make ncurses-dev
 
 WORKDIR /root/
 RUN curl -L https://github.com/cisco/ChezScheme/releases/download/v9.6.4/csv9.6.4.tar.gz | tar -zx
@@ -12,16 +12,20 @@ WORKDIR /root/ChezScheme
 RUN ./configure --threads --disable-x11
 RUN make && make install
 
+WORKDIR /root/
+RUN git clone https://github.com/gwatt/chez-exe.git
+
+WORKDIR /root/chez-exe/
+
+RUN /usr/bin/scheme --script gen-config.ss --bootpath /usr/lib/csv9.6.4/ta6le
+RUN make install
 
 
-FROM akkuscm/akku
-RUN apk update && apk --no-cache --update add bash
 
-# Ensure that there are no collisions
-RUN rm -rf /usr/lib/csv9.6.4/
-
-COPY --from=build-chez /usr/bin/scheme /usr/bin/
-COPY --from=build-chez /usr/lib/csv9.6.4/ /usr/lib/csv9.6.4/
+# Install project with akku (in Alpine)
+FROM akkuscm/akku AS akku-install
+RUN apk update && apk --no-cache --update add \
+        bash
 
 RUN mkdir /root/scheme-langserver/
 WORKDIR /root/scheme-langserver/
@@ -37,10 +41,29 @@ COPY virtual-file-system /root/scheme-langserver/virtual-file-system/
 COPY analysis /root/scheme-langserver/analysis/
 COPY tests /root/scheme-langserver/tests/
 
-COPY scheme-langserver.sls output-type-analysis.ss test.sh run.ss /root/scheme-langserver/
+COPY scheme-langserver.sls output-type-analysis.ss test.sh run.ss build.sh /root/scheme-langserver/
 
-# Install project
 RUN akku install
 
 
-ENTRYPOINT [ "./test.sh" ]
+
+# Put it all together in Debian
+FROM debian:bullseye
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y git make build-essential uuid-dev
+
+# add chez scheme
+COPY --from=build-chez /usr/bin/scheme /usr/bin/
+COPY --from=build-chez /usr/lib/csv9.6.4/ /usr/lib/csv9.6.4/
+
+# add compile-chez-program
+COPY --from=build-chez /usr/local/bin/compile-chez-program /usr/local/bin/
+COPY --from=build-chez /usr/local/lib/full-chez.a /usr/local/lib/
+COPY --from=build-chez /usr/local/lib/petite-chez.a /usr/local/lib/
+
+# add project
+COPY --from=akku-install /root/scheme-langserver/ /root/scheme-langserver/
+
+WORKDIR /root/scheme-langserver/
+


### PR DESCRIPTION
cc @ufo5260987423 
Aims to resolve #48

I decided to build Chez Scheme manually because I couldn't find the library with thread support in Weinholt's docker image. Other than that, `run` _should_ work on glibc Linux. https://github.com/konst-aa/scheme-langserver/releases/tag/v1.7.2

Let me know your thoughts!

Note: I will squash my commits (and remove tags if still present) when it's time to merge