### PR TITLE
Add Dockerfile.musl and action step for musl release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,23 +13,39 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build image
+      - name: Build Linux glibc image
         run: docker build .
 
-      - name: Compile
+      - name: Build Linux musl image
+        run: docker build -f Dockerfile.musl .
+
+      - name: Compile executable on Linux glibc
         run: |
-          mkdir build \
-          && docker run \
+          mkdir -p build
+          docker run \
             -v ./build:/root/scheme-langserver/build/ \
             $(docker build -q .) \
             bash -c 'source .akku/bin/activate
                      compile-chez-program run.ss
-                     mv run build/run || exit 1
+                     mv run build/scheme-langserver-x86_64-linux-glibc || exit 1
                      '
+
+      - name: Compile executable on Linux musl
+        run: |
+          mkdir -p build
+          docker run \
+            -v ./build:/root/scheme-langserver/build/ \
+            $(docker build -f Dockerfile.musl -q .) \
+            ash -c 'source .akku/bin/activate
+                    compile-chez-program run.ss
+                    mv run build/scheme-langserver-x86_64-linux-musl || exit 1
+                    '
 
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           repo: ufo5260987423/scheme-langserver
-          files: build/run
+          files: |
+            build/scheme-langserver-x86_64-linux-glibc
+            build/scheme-langserver-x86_64-linux-musl
 

--- a/Dockerfile.musl
+++ b/Dockerfile.musl
@@ -1,0 +1,71 @@
+# Install chez
+FROM alpine:latest AS build-chez
+
+# https://github.com/SWI-Prolog/swipl-devel/issues/235
+RUN apk update && apk add \
+        curl git alpine-sdk libuuid util-linux-dev make ncurses-dev
+
+WORKDIR /root/
+RUN curl -L https://github.com/cisco/ChezScheme/releases/download/v9.6.4/csv9.6.4.tar.gz | tar -zx
+RUN mv csv9.6.4 ChezScheme
+
+WORKDIR /root/ChezScheme
+RUN ./configure --threads --disable-x11
+RUN make && make install
+
+WORKDIR /root/
+RUN git clone https://github.com/gwatt/chez-exe.git
+
+WORKDIR /root/chez-exe/
+
+RUN /usr/bin/scheme --script gen-config.ss --bootpath /usr/lib/csv9.6.4/ta6le
+RUN make install
+
+
+
+# Install project with akku (in Alpine)
+FROM akkuscm/akku AS akku-install
+RUN apk update && apk --no-cache --update add \
+        bash
+
+RUN mkdir /root/scheme-langserver/
+WORKDIR /root/scheme-langserver/
+
+COPY Akku.lock Akku.manifest /root/scheme-langserver/
+
+# Install deps (most important operation to cache)
+RUN akku install
+
+COPY util /root/scheme-langserver/util/
+COPY protocol /root/scheme-langserver/protocol/
+COPY virtual-file-system /root/scheme-langserver/virtual-file-system/
+COPY analysis /root/scheme-langserver/analysis/
+COPY tests /root/scheme-langserver/tests/
+
+COPY scheme-langserver.sls output-type-analysis.ss test.sh run.ss build.sh /root/scheme-langserver/
+
+RUN akku install
+
+
+
+# Put it all together in Debian
+FROM alpine:latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apk update && apk add \
+        git alpine-sdk util-linux-dev libuuid make
+
+# add chez scheme
+COPY --from=build-chez /usr/bin/scheme /usr/bin/
+COPY --from=build-chez /usr/lib/csv9.6.4/ /usr/lib/csv9.6.4/
+
+# add compile-chez-program
+COPY --from=build-chez /usr/local/bin/compile-chez-program /usr/local/bin/
+COPY --from=build-chez /usr/local/lib/full-chez.a /usr/local/lib/
+COPY --from=build-chez /usr/local/lib/petite-chez.a /usr/local/lib/
+
+# add project
+COPY --from=akku-install /root/scheme-langserver/ /root/scheme-langserver/
+
+WORKDIR /root/scheme-langserver/
+


### PR DESCRIPTION
Seeks to close #66

I made a copy of our original Dockerfile, which is now based on a musl Linux distribution (alpine). I did a basic check on my Arch laptop for the glibc release, and the musl release in a separate Docker container. 

Here are the additional dependencies; the most notable one is libuuid, which doesn't always come preinstalled

```
[nix-shell:~/code/scheme-langserver/build]$ patchelf --print-needed scheme-langserver-x86_64-linux-glibc 
libdl.so.2
libm.so.6
libuuid.so.1
libpthread.so.0
libc.so.6

[nix-shell:~/code/scheme-langserver/build]$ patchelf --print-needed scheme-langserver-x86_64-linux-musl  
libuuid.so.1
libc.musl-x86_64.so.1
```
