### PR TITLE
Add `--help` flag to guide the executable uages

### DIFF
--- a/run.ss
+++ b/run.ss
@@ -1,4 +1,18 @@
-(import 
-    (chezscheme) 
+(import
+    (chezscheme)
     (scheme-langserver))
-(apply init-server (command-line-arguments))
+
+(let ([arg (command-line-arguments)])
+  (if (and (pair? arg) (equal? (car arg) "--help"))
+      (begin
+        (display "Usage: run [input-port] [output-port] [log-path] [enable-multi-thread?] [type-inference?]\n")
+        (display "Arguments:\n")
+        (display "  input-port            Port to read messages (default: stdin)\n")
+        (display "  output-port           Port to write messages (default: stdout)\n")
+        (display "  log-path              Path to write log output (default: null)\n")
+        (display "  enable-multi-thread?  enable | disable (default: disable)\n")
+        (display "  type-inference?       enable | disable (defaule: disable)\n")
+        (display "Example Usage:\n")
+        (display "  ./run ~/mylog.txt enable enable\n")
+        (exit 0)))
+  (apply init-server arg))

--- a/run.ss
+++ b/run.ss
@@ -5,7 +5,9 @@
 (let ([arg (command-line-arguments)])
   (if (and (pair? arg) (equal? (car arg) "--help"))
       (begin
-        (display "Usage: run [input-port] [output-port] [log-path] [enable-multi-thread?] [type-inference?]\n")
+        (display "Usage:\n")
+        (display "  ./run --help\n")
+        (display "  ./run [input-port] [output-port] [log-path] [enable-multi-thread?] [type-inference?]\n")
         (display "Arguments:\n")
         (display "  input-port            Port to read messages (default: stdin)\n")
         (display "  output-port           Port to write messages (default: stdout)\n")
@@ -13,6 +15,6 @@
         (display "  enable-multi-thread?  enable | disable (default: disable)\n")
         (display "  type-inference?       enable | disable (defaule: disable)\n")
         (display "Example Usage:\n")
-        (display "  ./run ~/mylog.txt enable enable\n")
+        (display "  ./run /path/to/scheme-langserver.log enable enable\n")
         (exit 0)))
   (apply init-server arg))


### PR DESCRIPTION
This PR adds support for the `--help` flag in `run`. When invoked, it displays usage instructions and exits cleanly without launching the server. This improves the user experience by clarifying the expected arguments and example usage.

```bash
> ./run --help
Usage:
  ./run --help
  ./run [input-port] [output-port] [log-path] [enable-multi-thread?] [type-inference?]
Arguments:
  input-port            Port to read messages (default: stdin)
  output-port           Port to write messages (default: stdout)
  log-path              Path to write log output (default: null)
  enable-multi-thread?  enable | disable (default: disable)
  type-inference?       enable | disable (defaule: disable)
Example Usage:
  ./run /path/to/scheme-langserver.log enable enable
  ```